### PR TITLE
fix: use declarativeNetRequestWithHostAccess to avoid broad permission warning

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -17,7 +17,7 @@
     "https://www.youtube.com/shorts*"
   ],
   "permissions": [
-    "declarativeNetRequest",
+    "declarativeNetRequestWithHostAccess",
     "storage"
   ],
   "action": {


### PR DESCRIPTION
## Summary
- Replaced `declarativeNetRequest` with `declarativeNetRequestWithHostAccess` in manifest.json to eliminate the "Block content on all web sites" permission warning
- Extension functionality remains identical since we already have the required `host_permissions` for YouTube domains
- Addresses user feedback in issue #8

## Test plan
- [x] Built extension successfully with `make chrome`
- [x] Verified manifest.json syntax is correct
- [x] Permission change only affects warning display, not functionality
- [x] Test loading extension in browser to confirm no permission warning appears

Closes #8