### PR TITLE
Fix error 152/153 on youtube-nocookie.com embeds by injecting Referer header on Firefox

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,0 +1,76 @@
+const B = typeof browser !== 'undefined' ? browser : chrome;
+
+let settings = { enabled: true, nocookie: true };
+
+function loadSettings() {
+  B.storage.local.get(['enabled', 'nocookie'], (result) => {
+    settings = {
+      enabled: result.enabled !== false,
+      nocookie: result.nocookie !== false,
+    };
+  });
+}
+
+loadSettings();
+
+B.storage.onChanged.addListener((changes, area) => {
+  if (area !== 'local') return;
+  if ('enabled' in changes) settings.enabled = changes.enabled.newValue !== false;
+  if ('nocookie' in changes) settings.nocookie = changes.nocookie.newValue !== false;
+});
+
+// Redirect youtube.com/watch and /shorts → embed URL, with timestamp conversion
+B.webRequest.onBeforeRequest.addListener(
+  (details) => {
+    if (!settings.enabled) return {};
+
+    const url = new URL(details.url);
+    const domain = settings.nocookie ? 'youtube-nocookie.com' : 'youtube.com';
+
+    if (url.pathname === '/watch') {
+      const videoId = url.searchParams.get('v');
+      if (!videoId) return {};
+      const embedUrl = new URL(`https://www.${domain}/embed/${videoId}`);
+      const t = url.searchParams.get('t');
+      if (t) embedUrl.searchParams.set('start', t);
+      return { redirectUrl: embedUrl.toString() };
+    }
+
+    const shortsMatch = url.pathname.match(/^\/shorts\/([^/?]+)/);
+    if (shortsMatch) {
+      return { redirectUrl: `https://www.${domain}/embed/${shortsMatch[1]}` };
+    }
+
+    return {};
+  },
+  {
+    urls: [
+      '*://*.youtube.com/watch*',
+      '*://*.youtube.com/shorts/*',
+    ],
+    types: ['main_frame'],
+  },
+  ['blocking']
+);
+
+// Inject Referer on embed requests — YouTube returns error 152/153 without it
+// when the embed URL is navigated to directly (Sec-Fetch-Site: none).
+B.webRequest.onBeforeSendHeaders.addListener(
+  (details) => {
+    if (!settings.enabled) return {};
+
+    const headers = (details.requestHeaders || []).filter(
+      (h) => h.name.toLowerCase() !== 'referer'
+    );
+    headers.push({ name: 'Referer', value: 'https://example.com' });
+    return { requestHeaders: headers };
+  },
+  {
+    urls: [
+      '*://www.youtube-nocookie.com/embed/*',
+      '*://www.youtube.com/embed/*',
+    ],
+    types: ['main_frame'],
+  },
+  ['blocking', 'requestHeaders']
+);

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 3,
-  "version": "0.2.0",
+  "version": "0.3.0",
   "name": "Redirect Youtube Video to Embed Page",
   "description": "Automatically redirects video pages to their embed equivalent.",
   "short_name": "yt2embed",
@@ -11,15 +11,19 @@
     "256": "assets/icon_256.png"
   },
   "host_permissions": [
-    "https://youtube.com/watch*",
-    "https://www.youtube.com/watch*",
-    "https://youtube.com/shorts*",
-    "https://www.youtube.com/shorts*"
+    "*://*.youtube.com/watch*",
+    "*://*.youtube.com/shorts/*",
+    "*://www.youtube-nocookie.com/embed/*",
+    "*://www.youtube.com/embed/*"
   ],
   "permissions": [
-    "declarativeNetRequestWithHostAccess",
-    "storage"
+    "storage",
+    "webRequest",
+    "webRequestBlocking"
   ],
+  "background": {
+    "scripts": ["background.js"]
+  },
   "action": {
     "default_popup": "popup.html",
     "default_title": "Settings - yt2embed",

--- a/popup.js
+++ b/popup.js
@@ -1,54 +1,41 @@
-// Extension state constants
 const STORAGE_KEY = 'enabled';
 const FALLBACK_STORAGE_KEY = 'yt2embed_enabled';
 const DEFAULT_ENABLED = true;
 
-// Privacy mode constants
 const NOCOOKIE_KEY = 'nocookie';
 const FALLBACK_NOCOOKIE_KEY = 'yt2embed_nocookie';
-const DEFAULT_NOCOOKIE = true; // Default to privacy mode
+const DEFAULT_NOCOOKIE = true;
 
 document.addEventListener('DOMContentLoaded', function() {
-  
   const toggle = document.getElementById('toggle');
   const status = document.getElementById('status');
   const nocookieToggle = document.getElementById('nocookie-toggle');
   const nocookieStatus = document.getElementById('nocookie-status');
   const infoIcon = document.querySelector('.info-icon');
-  
-  // Browser API detection
+
   function getAPI() {
-    if (typeof chrome !== 'undefined' && chrome.storage && chrome.declarativeNetRequest) {
-      return chrome;
-    } else if (typeof browser !== 'undefined' && browser.storage && browser.declarativeNetRequest) {
-      return browser;
-    }
+    if (typeof browser !== 'undefined' && browser.storage) return browser;
+    if (typeof chrome !== 'undefined' && chrome.storage) return chrome;
     return null;
   }
-  
+
   const browserAPI = getAPI();
-  
-  // Generic storage getter function
+
   function getStorageValue(key, fallbackKey, defaultValue = true) {
     if (browserAPI) {
       return new Promise((resolve) => {
         browserAPI.storage.local.get([key], function(result) {
           if (browserAPI.runtime.lastError) {
-            console.log(`Using localStorage fallback for ${key} due to:`, browserAPI.runtime.lastError);
-            const value = localStorage.getItem(fallbackKey) !== 'false';
-            resolve(value);
+            resolve(localStorage.getItem(fallbackKey) !== 'false');
           } else {
             resolve(result[key] !== false);
           }
         });
       });
-    } else {
-      const value = localStorage.getItem(fallbackKey) !== 'false';
-      return Promise.resolve(value);
     }
+    return Promise.resolve(localStorage.getItem(fallbackKey) !== 'false');
   }
-  
-  // Generic storage setter function
+
   function setStorageValue(key, fallbackKey, value) {
     if (browserAPI) {
       const storageObj = {};
@@ -58,112 +45,24 @@ document.addEventListener('DOMContentLoaded', function() {
           localStorage.setItem(fallbackKey, value.toString());
         }
       });
-      // Update rules after any storage change
-      updateDynamicRules();
     } else {
       localStorage.setItem(fallbackKey, value.toString());
     }
   }
-  
-  // Convenience functions for specific values
+
   const getEnabled = () => getStorageValue(STORAGE_KEY, FALLBACK_STORAGE_KEY, DEFAULT_ENABLED);
   const getNocookie = () => getStorageValue(NOCOOKIE_KEY, FALLBACK_NOCOOKIE_KEY, DEFAULT_NOCOOKIE);
   const setEnabled = (value) => setStorageValue(STORAGE_KEY, FALLBACK_STORAGE_KEY, value);
   const setNocookie = (value) => setStorageValue(NOCOOKIE_KEY, FALLBACK_NOCOOKIE_KEY, value);
-  
-  async function updateDynamicRules() {
-    // Early return if no browser API available
-    if (!browserAPI || !browserAPI.declarativeNetRequest) {
-      console.warn('Browser API or declarativeNetRequest not available');
-      return;
-    }
-    
-    try {
-      const [enabled, nocookie] = await Promise.all([getEnabled(), getNocookie()]);
-      
-      if (!enabled) {
-        // Extension disabled - remove all dynamic rules
-        await browserAPI.declarativeNetRequest.updateDynamicRules({
-          removeRuleIds: [1, 2]
-        });
-        return;
-      }
-      
-      // Extension enabled - set up rules based on nocookie preference
-      const domain = nocookie ? 'youtube-nocookie.com' : 'youtube.com';
-      
-      // Check if rules need updating to avoid unnecessary API calls
-      const existingRules = await browserAPI.declarativeNetRequest.getDynamicRules();
-      
-      // Add defensive checks for rule structure
-      const needsUpdate = !existingRules.find(rule => 
-        rule && 
-        rule.id === 1 && 
-        rule.action && 
-        rule.action.redirect && 
-        rule.action.redirect.regexSubstitution && 
-        rule.action.redirect.regexSubstitution.includes(domain)
-      );
-      
-      if (!needsUpdate) return; // Rules are already correct
-      
-      const newRules = [
-        {
-          "id": 1,
-          "priority": 1,
-          "action": {
-            "type": "redirect",
-            "redirect": {
-              "regexSubstitution": `https://www.${domain}/embed/\\1`
-            }
-          },
-          "condition": {
-            "regexFilter": ".*youtube\\.com/watch\\?v=([^&]+).*",
-            "resourceTypes": ["main_frame"]
-          }
-        },
-        {
-          "id": 2,
-          "priority": 1,
-          "action": {
-            "type": "redirect", 
-            "redirect": {
-              "regexSubstitution": `https://www.${domain}/embed/\\1`
-            }
-          },
-          "condition": {
-            "regexFilter": ".*youtube\\.com/shorts/([^&?]+).*",
-            "resourceTypes": ["main_frame"]
-          }
-        }
-      ];
-      
-      await browserAPI.declarativeNetRequest.updateDynamicRules({
-        removeRuleIds: [1, 2],
-        addRules: newRules
-      });
-      
-    } catch (error) {
-      console.error('Error updating dynamic rules:', error);
-      throw error; // Re-throw to allow callers to handle
-    }
-  }
-  
-  // Load current state and initialize rules
+
   Promise.all([getEnabled(), getNocookie()]).then(([isEnabled, isNocookie]) => {
     updateUI(isEnabled, isNocookie);
-    // Initialize dynamic rules based on current preferences
-    updateDynamicRules().catch(error => {
-      console.error('Failed to initialize rules:', error);
-      showError('Failed to initialize');
-    });
   }).catch(error => {
     console.error('Error loading state:', error);
     showError('Load error');
     updateUI(DEFAULT_ENABLED, DEFAULT_NOCOOKIE);
   });
-  
-  // Handle extension toggle click
+
   toggle.addEventListener('click', function() {
     Promise.all([getEnabled(), getNocookie()]).then(([currentEnabled, currentNocookie]) => {
       const newEnabled = !currentEnabled;
@@ -175,13 +74,10 @@ document.addEventListener('DOMContentLoaded', function() {
       showError('Toggle failed');
     });
   });
-  
-  // Handle nocookie toggle click
+
   nocookieToggle.addEventListener('click', function() {
     Promise.all([getEnabled(), getNocookie()]).then(([currentEnabled, currentNocookie]) => {
-      // Don't allow toggling privacy mode if extension is disabled
       if (!currentEnabled) return;
-      
       const newNocookie = !currentNocookie;
       setNocookie(newNocookie);
       updateUI(currentEnabled, newNocookie);
@@ -191,29 +87,27 @@ document.addEventListener('DOMContentLoaded', function() {
       showError('Toggle failed');
     });
   });
-  
+
   function updateUI(isEnabled, isNocookie) {
-    // Extension enabled/disabled toggle
     if (isEnabled) {
       toggle.classList.add('enabled');
       status.textContent = 'Enabled';
-      status.style.color = ''; // Reset color
+      status.style.color = '';
     } else {
       toggle.classList.remove('enabled');
       status.textContent = 'Disabled';
-      status.style.color = ''; // Reset color
+      status.style.color = '';
     }
-    
-    // Privacy mode (nocookie) toggle
+
     if (isNocookie) {
       nocookieToggle.classList.add('enabled');
     } else {
       nocookieToggle.classList.remove('enabled');
     }
+
     nocookieStatus.textContent = 'Privacy Mode';
-    nocookieStatus.style.color = ''; // Reset color
-    
-    // Disable/enable privacy mode controls based on extension state
+    nocookieStatus.style.color = '';
+
     if (isEnabled) {
       nocookieToggle.classList.remove('disabled');
       nocookieStatus.classList.remove('disabled');
@@ -224,13 +118,13 @@ document.addEventListener('DOMContentLoaded', function() {
       infoIcon.classList.add('disabled');
     }
   }
-  
+
   function showError(message) {
     status.textContent = message;
     status.style.color = '#d32f2f';
     nocookieStatus.style.color = '#d32f2f';
   }
-  
+
   function clearError() {
     status.style.color = '';
     nocookieStatus.style.color = '';


### PR DESCRIPTION

When the extension redirects a watch URL to `youtube-nocookie.com/embed/`, YouTube returns error 152 or 153 because the request arrives with `Sec-Fetch-Site: none` and no `Referer` header — the same signature as a direct address-bar navigation, which YouTube treats as an illegitimate embed context.

The fix is to inject `Referer: https://example.com` on the outgoing embed request. Any non-empty, syntactically valid Referer is sufficient; YouTube only checks for its presence.

**Approach**

Replaced `declarativeNetRequest` redirects with a background script using the `webRequest` API, mirroring how Header Editor solves this:

- `onBeforeRequest` — redirects `youtube.com/watch` and `/shorts` to the embed URL. Because this fires in the same request pipeline as `onBeforeSendHeaders`, the Referer is attached before the headers leave the browser (unlike `declarativeNetRequest`, which hands off to a separate navigation where the Referer slot is already empty).
- `onBeforeSendHeaders` — injects `Referer: https://example.com` on all requests to `youtube-nocookie.com/embed/*` and `youtube.com/embed/*`.

Firefox MV3 supports blocking `webRequest` listeners; this extension already targets Firefox exclusively via `browser_specific_settings.gecko`.

**Changes**

- `background.js` (new) — settings cache synced via `storage.onChanged`, redirect listener, Referer injection listener
- `manifest.json` — swapped `declarativeNetRequestWithHostAccess` for `webRequest` + `webRequestBlocking`; added embed URL host permissions; declared background script using `scripts` (not `service_worker`, for compatibility with Firefox forks such as Zen)
- `popup.js` — removed `updateDynamicRules()` and all `declarativeNetRequest` calls; popup is now purely a settings UI that writes to `storage.local`

**Bonus: timestamp preservation**

The `webRequest` redirect also converts `?t=` to `?start=` so `youtube.com/watch?v=ID&t=90` lands at `embed/ID?start=90`. This wasn't possible with `regexSubstitution` in `declarativeNetRequest`.

**Tested on** Zen Browser 1.19.13b (Firefox-based) and developed by Claude Code